### PR TITLE
Create basic error matching.

### DIFF
--- a/lib/gradle.js
+++ b/lib/gradle.js
@@ -6,6 +6,8 @@ function provideBuilder() {
   var fs = require('fs');
   var path = require('path');
 
+  var errorMatch = ['(?::compile(?:Api)?(?:Scala|Java|Groovy))?(?<file>.+):(?<line>\\d+):\\s.+[;:]'];
+
   return {
     niceName: 'Gradle',
 
@@ -19,13 +21,15 @@ function provideBuilder() {
           name: 'Gradle: assemble',
           exec: 'gradle',
           sh: false,
-          args: [ 'assemble' ]
+          args: [ 'assemble' ],
+          errorMatch: errorMatch
         },
         {
           name: 'Gradle: check',
           exec: 'gradle',
           sh: false,
-          args: [ 'check' ]
+          args: [ 'check' ],
+          errorMatch: errorMatch
         }
       ];
     }


### PR DESCRIPTION
May not work in all cases, but I have tested it to work with Scala builds.
