### PR TITLE
Support other file names

### DIFF
--- a/lib/gradle.js
+++ b/lib/gradle.js
@@ -1,7 +1,7 @@
 'use babel';
 'use strict';
 
-import { existsSync, stat, watch } from 'fs';
+import { readdirSync, stat, watch } from 'fs';
 import os from 'os';
 import path from 'path';
 import Promise from 'bluebird';
@@ -9,6 +9,7 @@ import { exec } from 'child_process';
 import EventEmitter from 'events';
 
 export function provideBuilder() {
+  const supportedFiles = ["build.gradle", "build.gradle.kts"];
   const statAsync = Promise.promisify(stat);
   const execAsync = Promise.promisify(exec);
   const errorMatch = [
@@ -61,13 +62,14 @@ export function provideBuilder() {
     }
 
     isEligible() {
-      this.file = path.join(this.cwd, 'build.gradle');
-      return existsSync(this.file);
+      const files = readdirSync(this.cwd);
+      this.file = files.find((f) => supportedFiles.includes(f));
+      return this.file !== undefined
     }
 
     settings() {
       const refresh = new Date();
-      this.fileWatcher = watch(this.file, () => {
+      this.fileWatcher = watch(path.join(this.cwd, this.file), () => {
         // Gradle touches the file when it's done, which will trigger this watch to
         // go off again. Require at least 3 second to pass before refreshing.
         if (new Date() - refresh > 3000) {


### PR DESCRIPTION
Gradle also allows for a build file called "build.gradle.kts".
Add support for a list of file names to check for.