### PR TITLE
Modify isEligble to accept build.gradle and build.gradle.kts formatted build files

### DIFF
--- a/lib/gradle.js
+++ b/lib/gradle.js
@@ -1,7 +1,7 @@
 'use babel';
 'use strict';
 
-import { existsSync, stat, watch } from 'fs';
+import { existsSync, stat, watch, readdirSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import Promise from 'bluebird';
@@ -61,8 +61,15 @@ export function provideBuilder() {
     }
 
     isEligible() {
-      this.file = path.join(this.cwd, 'build.gradle');
-      return existsSync(this.file);
+      let buildFiles = ['build.gradle', 'build.gradle.kts'];
+      let cwdFiles = readdirSync(this.cwd);
+      for (let buildFile of buildFiles) {
+        if (cwdFiles.includes(buildFile)) {
+          this.file = path.join(this.cwd, buildFile);
+          return existsSync(this.file);
+        }
+      }
+      return false;
     }
 
     settings() {


### PR DESCRIPTION
Added an array (buildFiles) to list the supported Gradle build file formats (build.gradle and build.gradle.kts).  If either of the file names is found in the current working directory, this.file is set to the full build file path and the existing 'existsSync' call is made.  If none of the supported build file names is found, then isEligible returns false.